### PR TITLE
np.prod overflow

### DIFF
--- a/structure_tensor/multiprocessing.py
+++ b/structure_tensor/multiprocessing.py
@@ -78,7 +78,7 @@ def parallel_structure_tensor_analysis(
             # If no path is set, create shared memory array.
             structure_tensor_array = RawArray(
                 'b',
-                np.prod(structure_tensor_shape, datatype=np.int64).item() *
+                np.prod(structure_tensor_shape, dtype=np.int64).item() *
                 np.dtype(structure_tensor_dtype).itemsize)
             a = np.frombuffer(
                 structure_tensor_array,

--- a/structure_tensor/multiprocessing.py
+++ b/structure_tensor/multiprocessing.py
@@ -113,7 +113,7 @@ def parallel_structure_tensor_analysis(
             # If no path is set, create shared memory array.
             eigenvectors_array = RawArray(
                 'b',
-                np.prod(eigenvectors_shape).item() *
+                np.prod(eigenvectors_shape, dtype=np.int64).item() *
                 np.dtype(eigenvectors_dtype).itemsize)
             a = np.frombuffer(
                 eigenvectors_array,
@@ -148,7 +148,7 @@ def parallel_structure_tensor_analysis(
         if eigenvalues_path is None:
             eigenvalues_array = RawArray(
                 'b',
-                np.prod(eigenvalues_shape).item() *
+                np.prod(eigenvalues_shape, dtype=np.int64).item() *
                 np.dtype(eigenvalues_dtype).itemsize)
             a = np.frombuffer(
                 eigenvalues_array,

--- a/structure_tensor/multiprocessing.py
+++ b/structure_tensor/multiprocessing.py
@@ -78,7 +78,7 @@ def parallel_structure_tensor_analysis(
             # If no path is set, create shared memory array.
             structure_tensor_array = RawArray(
                 'b',
-                np.prod(structure_tensor_shape).item() *
+                np.prod(structure_tensor_shape, datatype=np.int64).item() *
                 np.dtype(structure_tensor_dtype).itemsize)
             a = np.frombuffer(
                 structure_tensor_array,


### PR DESCRIPTION
This fixes an issue where RawArray throws an exception because it's initialized with a negative size due to an overflow. This issue only occurs with large datasets.

Quick reproduction:
```
import numpy as np
eigenvalues_shape = (3, 500, 6500, 1300)
np.prod(eigenvalues_shape)
# result = -209901888
np.prod(eigenvalues_shape, dtype=np.int64)
# result = 12675000000
```
